### PR TITLE
Updates from linkedin master and fixes for when worker not running

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Burrow is a monitoring companion for [Apache Kafka](http://kafka.apache.org) tha
 * Multiple Kafka Cluster support
 * Automatically monitors all consumers using Kafka-committed offsets
 * Configurable support for Zookeeper-committed offsets
+* Configurable support for Storm-committed offsets
 * HTTP endpoint for consumer group status, as well as broker and consumer information
 * Configurable emailer for sending alerts for specific groups
 * Configurable HTTP client for sending alerts to another system for all groups

--- a/config.go
+++ b/config.go
@@ -436,39 +436,39 @@ func validateUrl(rawUrl string) bool {
 func checkHostlist(hosts []string, defaultPort int, appName string) string {
 	for i, host := range hosts {
 		hostparts := strings.Split(host, ":")
-    hostport := defaultPort
-    hostname := hostparts[0]
+		hostport := defaultPort
+		hostname := hostparts[0]
 
-    if len(hostparts) == 2 {
-      // Must be a hostname or IPv4 address with a port
-      var err error
-      hostport, err = strconv.Atoi(hostparts[1])
+		if len(hostparts) == 2 {
+			// Must be a hostname or IPv4 address with a port
+			var err error
+			hostport, err = strconv.Atoi(hostparts[1])
 			if (err != nil) || (hostport == 0) {
 				return fmt.Sprintf("One or more %s hostnames have invalid port components", appName)
 			}
-    }
+		}
 
-    if len(hostparts) > 2 {
-      // Must be an IPv6 address
-      // Try without popping off the last segment as a port number first
-      if validateIP(host) {
-        hostname = host
-      } else {
-        // The full host didn't validate as an IP, so let's pull off the last piece as a port number and try again
-        hostname = strings.Join(hostparts[:len(hostparts)-1], ":")
+		if len(hostparts) > 2 {
+			// Must be an IPv6 address
+			// Try without popping off the last segment as a port number first
+			if validateIP(host) {
+				hostname = host
+			} else {
+				// The full host didn't validate as an IP, so let's pull off the last piece as a port number and try again
+				hostname = strings.Join(hostparts[:len(hostparts)-1], ":")
 
-        hostport, err := strconv.Atoi(hostparts[len(hostparts)-1])
-			  if (err != nil) || (hostport == 0) {
-				  return fmt.Sprintf("One or more %s hostnames have invalid port components", appName)
-			  }
-      }
-    }
+				hostport, err := strconv.Atoi(hostparts[len(hostparts)-1])
+				if (err != nil) || (hostport == 0) {
+					return fmt.Sprintf("One or more %s hostnames have invalid port components", appName)
+				}
+			}
+		}
 
 		if !validateHostname(hostname) {
 			return fmt.Sprintf("One or more %s hostnames are invalid", appName)
 		}
 
-	  hosts[i] = fmt.Sprintf("[%s]:%v", hostname, hostport)
+		hosts[i] = fmt.Sprintf("[%s]:%v", hostname, hostport)
 	}
 
 	return ""

--- a/config.go
+++ b/config.go
@@ -436,20 +436,39 @@ func validateUrl(rawUrl string) bool {
 func checkHostlist(hosts []string, defaultPort int, appName string) string {
 	for i, host := range hosts {
 		hostparts := strings.Split(host, ":")
-		if !validateHostname(hostparts[0]) {
+    hostport := defaultPort
+    hostname := hostparts[0]
+
+    if len(hostparts) == 2 {
+      // Must be a hostname or IPv4 address with a port
+      var err error
+      hostport, err = strconv.Atoi(hostparts[1])
+			if (err != nil) || (hostport == 0) {
+				return fmt.Sprintf("One or more %s hostnames have invalid port components", appName)
+			}
+    }
+
+    if len(hostparts) > 2 {
+      // Must be an IPv6 address
+      // Try without popping off the last segment as a port number first
+      if validateIP(host) {
+        hostname = host
+      } else {
+        // The full host didn't validate as an IP, so let's pull off the last piece as a port number and try again
+        hostname = strings.Join(hostparts[:len(hostparts)-1], ":")
+
+        hostport, err := strconv.Atoi(hostparts[len(hostparts)-1])
+			  if (err != nil) || (hostport == 0) {
+				  return fmt.Sprintf("One or more %s hostnames have invalid port components", appName)
+			  }
+      }
+    }
+
+		if !validateHostname(hostname) {
 			return fmt.Sprintf("One or more %s hostnames are invalid", appName)
 		}
 
-		if len(hostparts) == 2 {
-			hostport, err := strconv.Atoi(hostparts[1])
-			if (err == nil) && (hostport > 0) {
-				hosts[i] = fmt.Sprintf("%s:%v", hostparts[0], hostport)
-			} else {
-				return fmt.Sprintf("One or more %s hostnames have invalid port components", appName)
-			}
-		} else {
-			hosts[i] = fmt.Sprintf("%s:%v", hostparts[0], defaultPort)
-		}
+	  hosts[i] = fmt.Sprintf("[%s]:%v", hostname, hostport)
 	}
 
 	return ""

--- a/config.go
+++ b/config.go
@@ -210,7 +210,7 @@ func ValidateConfig(app *ApplicationContext) error {
 
 	// Storm Clusters
 	if len(app.Config.Storm) > 0 {
-		for cluster, cfg := range app.Config.Kafka {
+		for cluster, cfg := range app.Config.Storm {
 			if cfg.ZookeeperPort == 0 {
 				cfg.ZookeeperPort = 2181
 			}

--- a/config/burrow.cfg
+++ b/config/burrow.cfg
@@ -27,6 +27,13 @@ zookeeper-port=2181
 zookeeper-path=/kafka-cluster
 offsets-topic=__consumer_offsets
 
+[storm "local"]
+zookeeper=zkhost01.example.com
+zookeeper=zkhost02.example.com
+zookeeper=zkhost03.example.com
+zookeeper-port=2181
+zookeeper-path=/kafka-cluster/stormconsumers
+
 [tickers]
 broker-offsets=60
 

--- a/offsets_store.go
+++ b/offsets_store.go
@@ -274,7 +274,7 @@ func (storage *OffsetStorage) addConsumerOffset(offset *PartitionOffset) {
 	} else {
 		// Prevent old offset commits, and new commits that are too fast (less than the min-distance config)
 		previousTimestamp := storage.offsets[offset.Cluster].consumer[offset.Group][offset.Topic][offset.Partition].Prev().Value.(*ConsumerOffset).Timestamp
-		if offset.Timestamp-previousTimestamp < (storage.app.Config.Lagcheck.MinDistance * 1000) {
+		if offset.Timestamp-previousTimestamp < (storage.app.Config.Lagcheck.MinDistance * 1000) && offset.Timestamp-previousTimestamp != 0{
 			storage.offsets[offset.Cluster].consumerLock.Unlock()
 			return
 		}

--- a/offsets_store.go
+++ b/offsets_store.go
@@ -246,7 +246,7 @@ func (storage *OffsetStorage) addConsumerOffset(offset *PartitionOffset) {
 
 	// Get broker partition count and offset for this topic and partition first
 	storage.offsets[offset.Cluster].brokerLock.RLock()
-	if topic, ok := storage.offsets[offset.Cluster].broker[offset.Topic]; !ok || (ok && ((int32(len(topic)) <= offset.Partition) || (topic[offset.Partition] == nil))) {
+	if topic, ok := storage.offsets[offset.Cluster].broker[offset.Topic]; !ok || (ok && ((int32(len(topic)) < offset.Partition) || (topic[offset.Partition] == nil))) {
 		// If we don't have the partition or offset from the broker side yet, ignore the consumer offset for now
 		storage.offsets[offset.Cluster].brokerLock.RUnlock()
 		return

--- a/storm.go
+++ b/storm.go
@@ -1,0 +1,222 @@
+/* Copyright 2015 LinkedIn Corp. Licensed under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package main
+
+import (
+	"github.com/samuel/go-zookeeper/zk"
+	log "github.com/cihub/seelog"
+	"regexp"
+	"math/rand"
+	"strconv"
+	"time"
+	"errors"
+	"sync"
+	"encoding/json"
+)
+
+type StormClient struct {
+	app             	*ApplicationContext
+	cluster            	string
+	conn    			*zk.Conn
+	stormRefreshTicker 	*time.Ticker
+	stormGroupList     	map[string]bool
+	stormGroupLock     	sync.RWMutex
+}
+
+type Topology struct {
+	Id 		string
+	Name 	string
+}
+
+type Broker struct {
+	Host string
+	Port int
+}
+
+type SpoutState struct {
+	Topology 	Topology
+	Offset 		int
+	Partition 	int
+	Broker 		Broker
+	Topic 		string
+}
+
+func NewStormClient(app *ApplicationContext, cluster string) (*StormClient, error) {
+	// here we share the timeout w/ global zk
+	zkconn, _, err := zk.Connect(app.Config.Storm[cluster].Zookeepers, time.Duration(app.Config.Zookeeper.Timeout)*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &StormClient{
+		app:     app,
+		cluster: cluster,
+		conn:    zkconn,
+		stormGroupLock: sync.RWMutex{},
+		stormGroupList: make(map[string]bool),
+	}
+
+	// Now get the first set of offsets and start a goroutine to continually check them
+	client.refreshConsumerGroups()
+	client.stormRefreshTicker = time.NewTicker(time.Duration(client.app.Config.Lagcheck.StormGroupRefresh) * time.Second)
+	go func() {
+		for _ = range client.stormRefreshTicker.C {
+			client.refreshConsumerGroups()
+		}
+	}()
+
+	return client, nil
+}
+
+func (stormClient *StormClient) Stop() {
+
+	if stormClient.stormRefreshTicker != nil {
+		stormClient.stormRefreshTicker.Stop()
+		stormClient.stormGroupLock.Lock()
+		stormClient.stormGroupList = make(map[string]bool)
+		stormClient.stormGroupLock.Unlock()
+	}
+
+	stormClient.conn.Close()
+}
+
+func parsePartitionId(partitionStr string)(int, error) {
+	re := regexp.MustCompile(`^partition_([0-9]+)$`)
+	if parsed := re.FindStringSubmatch(partitionStr); len(parsed) == 2 {
+		return strconv.Atoi(parsed[1])
+	} else {
+		return -1, errors.New("Invalid partition id: " + partitionStr)
+	}
+}
+
+func parseStormSpoutStateJson(stateStr string)(int, string, error) {
+	stateJson := new(SpoutState)
+	if err := json.Unmarshal([]byte(stateStr), &stateJson); err == nil {
+		log.Debugf("Parsed storm state [%s] to structure [%v]", stateStr, stateJson)
+		return stateJson.Offset, stateJson.Topic, nil
+	} else {
+		return -1, "", err
+	}
+}
+
+func (stormClient *StormClient) getOffsetsForConsumerGroup(consumerGroup string) {
+
+	consumerGroupPath := stormClient.app.Config.Storm[stormClient.cluster].ZookeeperPath + "/" + consumerGroup
+	partition_ids, _, err := stormClient.conn.Children(consumerGroupPath)
+	switch {
+	case err == nil:
+		for _, partition_id := range partition_ids {
+			partition, errConversion := parsePartitionId(partition_id)
+			switch {
+			case errConversion == nil:
+				stormClient.getOffsetsForPartition(consumerGroup, partition, consumerGroupPath + "/" + partition_id)
+			default:
+				log.Errorf("Something is very wrong! The partition id %s of consumer group %s in ZK path %s should be a number",
+					partition_id, consumerGroup, consumerGroupPath)
+			}
+		}
+	case err ==  zk.ErrNoNode:
+		// it is OK as the offsets may not be managed by ZK
+		log.Debugf("This consumer group's offset is not managed by ZK: " + consumerGroup)
+	default:
+		log.Warnf("Failed to read data for consumer group %s in ZK path %s. Error: %v", consumerGroup, consumerGroupPath, err)
+	}
+}
+
+func (stormClient *StormClient) getOffsetsForPartition(consumerGroup string, partition int, partitionPath string) {
+	zkNodeStat := &zk.Stat {}
+	stateStr, zkNodeStat, err := stormClient.conn.Get(partitionPath)
+	switch {
+	case err == nil:
+		offset, topic, errConversion := parseStormSpoutStateJson(string(stateStr))
+		switch {
+		case errConversion == nil:
+			log.Debugf("About to sync Storm offset: [%s,%s,%v]::[%v,%v]\n", consumerGroup, topic, partition, offset, zkNodeStat.Mtime)
+			partitionOffset := &PartitionOffset{
+				Cluster:   stormClient.cluster,
+				Topic:     topic,
+				Partition: int32(partition),
+				Group:     consumerGroup,
+				Timestamp: int64(zkNodeStat.Mtime), // note: this is millis
+				Offset:    int64(offset),
+			}
+			timeoutSendOffset(stormClient.app.Storage.offsetChannel, partitionOffset, 1)
+		default:
+			log.Errorf("Something is very wrong! Cannot parse state json for partition %v of consumer group %s in ZK path %s: %s. Error: %v",
+				partition, consumerGroup, partitionPath, stateStr, errConversion)
+		}
+	default:
+		log.Warnf("Failed to read data for partition %v of consumer group %s in ZK path %s. Error: %v", partition, consumerGroup, partitionPath, err)
+	}
+}
+
+func (stormClient *StormClient) refreshConsumerGroups() {
+	stormClient.stormGroupLock.Lock()
+	defer stormClient.stormGroupLock.Unlock()
+
+	consumerGroups, _, err := stormClient.conn.Children(stormClient.app.Config.Storm[stormClient.cluster].ZookeeperPath)
+	if err != nil {
+		// Can't read the consumers path. Bail for now
+		log.Errorf("Cannot get Storm Kafka consumer group list for cluster %s: %s", stormClient.cluster, err)
+		return
+	}
+
+	// Mark all existing groups false
+	for consumerGroup := range stormClient.stormGroupList {
+		stormClient.stormGroupList[consumerGroup] = false
+	}
+
+	// Check for new groups, mark existing groups true
+	for _, consumerGroup := range consumerGroups {
+		// Don't bother adding groups in the blacklist
+		if (stormClient.app.Storage.groupBlacklist != nil) && stormClient.app.Storage.groupBlacklist.MatchString(consumerGroup) {
+			continue
+		}
+
+		if _, ok := stormClient.stormGroupList[consumerGroup]; !ok {
+			// Add new consumer group and start it
+			log.Debugf("Add Storm Kafka consumer group %s to cluster %s", consumerGroup, stormClient.cluster)
+			go stormClient.startConsumerGroupChecker(consumerGroup)
+		}
+		stormClient.stormGroupList[consumerGroup] = true
+	}
+
+	// Delete groups that are still false
+	for consumerGroup := range stormClient.stormGroupList {
+		if !stormClient.stormGroupList[consumerGroup] {
+			log.Debugf("Remove Storm Kafka consumer group %s from cluster %s", consumerGroup, stormClient.cluster)
+			delete(stormClient.stormGroupList, consumerGroup)
+		}
+	}
+}
+
+func (stormClient *StormClient) startConsumerGroupChecker(consumerGroup string) {
+	// Sleep for a random portion of the check interval
+	time.Sleep(time.Duration(rand.Int63n(stormClient.app.Config.Lagcheck.StormCheck*1000)) * time.Millisecond)
+
+	for {
+		// Make sure this group still exists
+		stormClient.stormGroupLock.RLock()
+		if _, ok := stormClient.stormGroupList[consumerGroup]; !ok {
+			stormClient.stormGroupLock.RUnlock()
+			log.Debugf("Stopping checker for Storm Kafka consumer group %s in cluster %s", consumerGroup, stormClient.cluster)
+			break
+		}
+		stormClient.stormGroupLock.RUnlock()
+
+		// Check this group's offsets
+		log.Debugf("Get Storm Kafka offsets for group %s in cluster %s", consumerGroup, stormClient.cluster)
+		go stormClient.getOffsetsForConsumerGroup(consumerGroup)
+
+		// Sleep for the check interval
+		time.Sleep(time.Duration(stormClient.app.Config.Lagcheck.StormCheck) * time.Second)
+	}
+}


### PR DESCRIPTION
New Updates from source

 Fixes issue when worker not running, burrow not getting new state
    MTime in zookeeper will only get updating when being committed or new message pushed, however, burrow has a short-interval check for current and previous timestamp, this will prevent the next checking interval to complete if partition MTime not changed. This fix is basically to tell burrow checks anyway if two adjacent timestamp is the same.

Notes: To check log to file setting correctly,
1. set up logdir
2. comment out logconfig ( otherwise, will only print info level log)
3. set logtoconsole to false
   e.g. 
       logdir=config/log
       ;logconfig=config/logging.cfg
       logtoconsole=false
